### PR TITLE
Remove fetch-depth from checkout step

### DIFF
--- a/.github/workflows/TnTComponentsToNuget.yml
+++ b/.github/workflows/TnTComponentsToNuget.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      with:
-          fetch-depth: 0
 
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v3.1.1


### PR DESCRIPTION
The `fetch-depth` option was removed from the `Checkout repository` step in the `TnTComponentsToNuget.yml` file. This change may affect how much of the repository's history is fetched during the checkout process, potentially allowing for a full history to be available for subsequent steps.