### PR TITLE
Update checkout step to fetch full repository history

### DIFF
--- a/.github/workflows/TnTComponentsToNuget.yml
+++ b/.github/workflows/TnTComponentsToNuget.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+          fetch-depth: 0
 
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v3.1.1


### PR DESCRIPTION
Added `fetch-depth: 0` to the `Checkout repository` step in `TnTComponentsToNuget.yml` to allow fetching the entire commit history, enabling operations that require access to previous commits.