### PR TITLE
Refactor StateHasChanged invocation in TnTToast

### DIFF
--- a/TnTComponents/Toast/TnTToast.cs
+++ b/TnTComponents/Toast/TnTToast.cs
@@ -149,7 +149,7 @@ public class TnTToast : ComponentBase, IDisposable {
             _incrementAction = async () => {
                 while (_toasts.Count != 0) {
                     await Task.Delay(100);
-                    StateHasChanged();
+                    await InvokeAsync(StateHasChanged);
                 }
             };
 


### PR DESCRIPTION
Refactor StateHasChanged invocation in TnTToast

Updated the asynchronous action to use await InvokeAsync(StateHasChanged) instead of direct StateHasChanged() call. This change ensures proper synchronization context for UI updates in Blazor applications.