### PR TITLE
Add BuildRenderTree method to TnTToast class

### DIFF
--- a/TnTComponents/Toast/TnTToast.cs
+++ b/TnTComponents/Toast/TnTToast.cs
@@ -36,6 +36,7 @@ public class TnTToast : ComponentBase, IDisposable {
         GC.SuppressFinalize(this);
     }
 
+    /// <inheritdoc />
     protected override void BuildRenderTree(RenderTreeBuilder builder) {
         if (_toasts.Any()) {
             builder.OpenElement(0, "div");


### PR DESCRIPTION
Add BuildRenderTree method to TnTToast class

Updated the `TnTToast` class to include the `BuildRenderTree` method, which overrides the base implementation to render toast notifications. The method checks for existing toasts and opens a `div` element with a designated CSS class for styling.