### PR TITLE
Update github-tag-action and remove NuGet push step

### DIFF
--- a/.github/workflows/TnTComponentsToNuget.yml
+++ b/.github/workflows/TnTComponentsToNuget.yml
@@ -51,7 +51,7 @@ jobs:
     - run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
     - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@v1.71.0 # Don't use @master or @v1 unless you're happy to test the latest version
+      uses: anothrNick/github-tag-action@v1 # Don't use @master or @v1 unless you're happy to test the latest version
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # if you don't want to set write permissions use a PAT token
         WITH_V: false


### PR DESCRIPTION
Update github-tag-action and remove NuGet push step

Updated the `github-tag-action` version from `v1.71.0` to `v1`, which may change the tagging behavior. Removed the step that automatically pushes generated NuGet packages to the repository.